### PR TITLE
Manually install Terraform during docs generation run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - run: go generate ./...
       - name: git diff
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 terraform 1.1.9
+golang 1.24.1


### PR DESCRIPTION
This seems to have happened automatically in the past but no longer did. `terraform-provider-scaffolding-framework` [explicitly installs Terraform](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/test.yml) so we'll match that.