### PR TITLE
Prevent token deprecation warning

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,14 +27,14 @@ func New(version string) func() *schema.Provider {
 				"token": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					DefaultFunc: schema.EnvDefaultFunc("PRISMATIC_TOKEN", ""),
+					DefaultFunc: schema.EnvDefaultFunc("PRISMATIC_TOKEN", nil),
 					Description: "An [access token obtained with Prism CLI](https://prismatic.io/docs/cli/prism/#metoken) of Prismatic API calls.",
 					Deprecated:  "Access token use has been deprecated in favor of using refresh tokens. Please migrate provider configuration to use the new refresh_token attribute instead.",
 				},
 				"refresh_token": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					DefaultFunc: schema.EnvDefaultFunc("PRISMATIC_REFRESH_TOKEN", ""),
+					DefaultFunc: schema.EnvDefaultFunc("PRISMATIC_REFRESH_TOKEN", nil),
 					Description: "A [refresh token to use for headless authentication](https://prismatic.io/docs/cli/bash-scripting/#headless-prism-usage-for-cicd-pipelines) to the Prismatic API.",
 				},
 			},


### PR DESCRIPTION
Currently, if you don't have a `PRISMATIC_TOKEN` environment variable set and you don't have a `token` set in your `provider` block, you still get a deprecation warning `Access token use has been deprecated in favor of using refresh tokens. Please migrate provider configuration to use the new refresh_token attribute instead.`

Turns out, you need to default those values to `nil` rather than `""`.

Verified the provider still works when defaulting to `nil` 👍 